### PR TITLE
POC - Enable DO Snap for DU Snap integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ _deps
 *_CPack_Packages/
 *.deb
 out/
+
+# Snapcraft output files
+*.snap
+squashfs-root/

--- a/client-lite/src/util/do_persistence.cpp
+++ b/client-lite/src/util/do_persistence.cpp
@@ -27,7 +27,11 @@ const std::string& GetConfigDirectory()
 
 const std::string& GetSDKConfigFilePath()
 {
+#ifdef DO_BUILD_FOR_SNAP
+    static std::string configFilePath(DO_CONFIG_DIRECTORY_PATH "/configs/sdk-config.json");
+#else
     static std::string configFilePath(DO_CONFIG_DIRECTORY_PATH "/sdk-config.json");
+#endif
     return configFilePath;
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,3 +120,14 @@ slots:
     interface: content
     content: config-file
     write: [ $SNAP_DATA/etc/deliveryoptimization-agent/configs ]
+
+plugs:
+  client-downloads-folder:
+    interface: content
+    content: client-downloads-folder
+    target: $SNAP_DATA/deliveryoptimization-snap-downloads-root
+
+layout:
+# adu_data_dir
+  /var/lib/deliveryoptimization-snap-downloads-root:
+    symlink: $SNAP_DATA/deliveryoptimization-snap-downloads-root

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,41 @@ parts:
       - libssh-4
       - libwind0-heimdal
 
+  sdk:
+    plugin: python
+    source: .
+    override-build: |
+      python3 ./build/build.py --project sdk --build-for-snap --package-for deb
+      mkdir -p ../install/bin
+      cp /tmp/build-deliveryoptimization-sdk/linux-debug/libdeliveryoptimization*.0.0_amd64.deb ../install/bin
+
+    after:
+      - installdeps
+
+    build-packages:
+      - file
+
+    stage-packages:
+      - libasn1-8-heimdal
+      - libboost-filesystem1.71.0
+      - libbrotli1
+      - libcurl4
+      - libgssapi3-heimdal
+      - libhcrypto4-heimdal
+      - libheimbase1-heimdal
+      - libheimntlm0-heimdal
+      - libhx509-5-heimdal
+      - libkrb5-26-heimdal
+      - libldap-2.4-2
+      - libnghttp2-14
+      - libproxy1v5
+      - libpsl5
+      - libroken18-heimdal
+      - librtmp1
+      - libsasl2-2
+      - libssh-4
+      - libwind0-heimdal
+
 apps:
   deliveryoptimization-client:
     command: bin/deliveryoptimization-agent
@@ -80,7 +115,8 @@ slots:
     content: port-number
     read: [ $SNAP_DATA/var/run/deliveryoptimization-agent ]
 
+  # Share a folder containing sdk-config.json
   config-file:
     interface: content
     content: config-file
-    write: [ $SNAP_DATA/etc/deliveryoptimization-agent/sdk-config.json ]
+    write: [ $SNAP_DATA/etc/deliveryoptimization-agent/configs ]


### PR DESCRIPTION
- Use separate ('configs') folder for sdk-config.json file. (This is optional)
- Create content-download-folder plug that can be used for sharing content between DO and DU snap
- [For testing purposes] Add 'sdk' part in DO snap, so that we can use it for sdk installation, if needed.